### PR TITLE
feat: add GitHub Action for PR validation

### DIFF
--- a/.github/workflows/pr-validation.yaml
+++ b/.github/workflows/pr-validation.yaml
@@ -1,0 +1,59 @@
+name: PR Validation
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  issue_comment:
+    types: [created]
+
+jobs:
+  validate:
+    name: Validate PR
+    runs-on: ubuntu-latest
+    # Only run on PR comments with /test from repository owner
+    if: |
+      (github.event_name == 'pull_request') ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request &&
+       contains(github.event.comment.body, '/test') &&
+       github.event.comment.user.login == github.repository_owner)
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          # For issue_comment events, checkout the PR branch
+          ref: ${{ github.event_name == 'issue_comment' && format('refs/pull/{0}/head', github.event.issue.number) || github.ref }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+
+      - name: Run make test
+        run: make test
+
+      - name: Comment on PR (success)
+        if: success() && github.event_name == 'issue_comment'
+        uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: '✅ Tests passed successfully!'
+            })
+
+      - name: Comment on PR (failure)
+        if: failure() && github.event_name == 'issue_comment'
+        uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: '❌ Tests failed. Please check the workflow logs for details.'
+            })


### PR DESCRIPTION
Add workflow that:
- Triggers automatically on all PRs (opened, synchronize, reopened)
- Re-triggers on /test comment from repository owner
- Runs 'make test' to validate the build
- Posts status comments on /test triggers