### PR TITLE
fix: only replace datetime fields within frontmatter

### DIFF
--- a/.github/workflows/new-post-from-issues.yaml
+++ b/.github/workflows/new-post-from-issues.yaml
@@ -23,7 +23,23 @@ jobs:
           echo "title=$title" >> "$GITHUB_OUTPUT"
       - name: Create Content File
         run: |
-          echo -e "---\n${BODY}" | sed -e "s/publishDate:/publishDate: $(TZ=-9 date -Iseconds)/" | sed -e "s/modDatetime:/modDatetime: $(TZ=-9 date -Iseconds)/" >> posts/${{ steps.define_title.outputs.title }}.md
+          echo -e "---\n${BODY}" | awk -v dt="$(TZ=-9 date -Iseconds)" '
+            BEGIN { frontmatter_count=0 }
+            /^---$/ {
+              frontmatter_count++
+              print
+              next
+            }
+            frontmatter_count == 1 && /^publishDate:/ {
+              print "publishDate: " dt
+              next
+            }
+            frontmatter_count == 1 && /^modDatetime:/ {
+              print "modDatetime: " dt
+              next
+            }
+            { print }
+          ' >> posts/${{ steps.define_title.outputs.title }}.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BODY: ${{ github.event.issue.body }}

--- a/.github/workflows/sync-pr-from-issue-update.yaml
+++ b/.github/workflows/sync-pr-from-issue-update.yaml
@@ -166,8 +166,20 @@ jobs:
           fi
 
           # Update the file with new content, preserving the frontmatter structure
-          # Update modDatetime to current time
-          echo -e "---\n${issue_body}" | sed -e "s/modDatetime:/modDatetime: $(TZ=-9 date -Iseconds)/" > "$filepath"
+          # Update modDatetime to current time (only in frontmatter)
+          echo -e "---\n${issue_body}" | awk -v dt="$(TZ=-9 date -Iseconds)" '
+            BEGIN { frontmatter_count=0 }
+            /^---$/ {
+              frontmatter_count++
+              print
+              next
+            }
+            frontmatter_count == 1 && /^modDatetime:/ {
+              print "modDatetime: " dt
+              next
+            }
+            { print }
+          ' > "$filepath"
 
           echo "Updated $filepath with latest issue content"
 


### PR DESCRIPTION
- Updated both workflows to use awk instead of sed
- Datetime replacements now only occur in frontmatter section
- Prevents accidental replacement of datetime fields in post content