### PR TITLE
fix: prevent escape sequence expansion in issue body

### DIFF
--- a/.github/workflows/new-post-from-issues.yaml
+++ b/.github/workflows/new-post-from-issues.yaml
@@ -23,7 +23,7 @@ jobs:
           echo "title=$title" >> "$GITHUB_OUTPUT"
       - name: Create Content File
         run: |
-          echo -e "---\n${BODY}" | awk -v dt="$(TZ=-9 date -Iseconds)" '
+          printf "---\n%s" "${BODY}" | awk -v dt="$(TZ=-9 date -Iseconds)" '
             BEGIN { frontmatter_count=0 }
             /^---$/ {
               frontmatter_count++

--- a/.github/workflows/sync-pr-from-issue-update.yaml
+++ b/.github/workflows/sync-pr-from-issue-update.yaml
@@ -167,7 +167,7 @@ jobs:
 
           # Update the file with new content, preserving the frontmatter structure
           # Update modDatetime to current time (only in frontmatter)
-          echo -e "---\n${issue_body}" | awk -v dt="$(TZ=-9 date -Iseconds)" '
+          printf "---\n%s" "${issue_body}" | awk -v dt="$(TZ=-9 date -Iseconds)" '
             BEGIN { frontmatter_count=0 }
             /^---$/ {
               frontmatter_count++


### PR DESCRIPTION
- Replace 'echo -e' with 'printf' using %s format specifier
- This preserves literal escape sequences like \n in issue body text
- Fixes both sync-pr-from-issue-update.yaml and new-post-from-issues.yaml