### PR TITLE
fix: correct date format in deno LOG_TOKENS post to fix make test

### DIFF
--- a/posts/2026-06-10_deno-log-tokens-env-required.md
+++ b/posts/2026-06-10_deno-log-tokens-env-required.md
@@ -2,9 +2,9 @@
 title: denoスクリプトで LOG_TOKENS 環境変数の要求をされた原因
 tags: deno
 author: Cj-bc
-publishDate: "[2026-06-10 12:49:23+00:00]"
-modDatetime: "[2026-06-10 12:49:23+00:00]"
-date: "[2026-06-10 12:49:23+00:00]"
+publishDate: "[2026-06-10 Wed 12:49]"
+modDatetime: "[2026-06-10 Wed 12:49]"
+date: "[2026-06-10 Wed 12:49]"
 kind: Memo
 progress: WIP
 status: Normal


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- PR #127 の `make test` 失敗を修正
- `posts/2026-06-10_deno-log-tokens-env-required.md` の日付フォーマットが `"[2026-06-10 12:49:23+00:00]"` という不正な形式だった
- `astro-ink/src/content/config.ts` の正規表現 `/\[(\d{4}-\d{2}-\d{2}) ...(?: (\d{2}:\d{2}))?\]/` はorg-mode形式 `[YYYY-MM-DD Ddd HH:MM]` を期待しているため、マッチに失敗しNullPointerエラーが発生していた
- `[2026-06-10 Wed 12:49]` の正しい形式に修正

## Test plan

- [ ] `make test` が通ることを確認 (`make blog-build` でAstroビルドが成功する)

https://claude.ai/code/session_01FLFbfAnnh2v3nCUM2Q3vga
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FLFbfAnnh2v3nCUM2Q3vga)_